### PR TITLE
Changed mabs timer to treat MIN_POLL_TIME_US as microseconds instead …

### DIFF
--- a/lib_mic_array_board_support/src/board_support.xc
+++ b/lib_mic_array_board_support/src/board_support.xc
@@ -89,7 +89,7 @@ void mabs_button_and_led_server(server interface mabs_led_button_if lb[n_lb],
         }
 
         case t when timerafter(time) :> unsigned now :{
-            time = now + MIN_POLL_TIME_US;
+            time = now + 100*MIN_POLL_TIME_US;
             unsigned elapsed = (now-start_of_time)&LED_MAX_COUNT;
             elapsed>>=(20-8);
             unsigned d=0;


### PR DESCRIPTION
…of 10's of nanoseconds

The mabs button and LED server was updating the LEDs every MIN_POLL_TIME_US reference clock ticks. But, the macro name implies that it should be updating the LEDs every MIN_POLL_TIME_US microseconds, rather than reference clock ticks. So, this fixes that. This also fixes an issue with the BGA167 boards where the MABS server is broken when the core clock is 500 MHz, because the timer is firing so rapidly it's never able to service any other events.