### PR TITLE
Makes LED client interface nullable for BGA167

### DIFF
--- a/lib_mic_array_board_support/api/mic_array_board_support.h
+++ b/lib_mic_array_board_support/api/mic_array_board_support.h
@@ -159,7 +159,7 @@ void mabs_button_and_led_server(server interface mabs_led_button_if lb[n_lb],
 #ifndef MIC_BOARD_LED_STCP
         mabs_led_ports_t &leds,
 #else
-        client interface ma_bga167_led_if leds,
+        client interface ma_bga167_led_if? leds,
 #endif
         in port p_buttons);
 

--- a/lib_mic_array_board_support/src/board_support.xc
+++ b/lib_mic_array_board_support/src/board_support.xc
@@ -89,7 +89,7 @@ void mabs_button_and_led_server(server interface mabs_led_button_if lb[n_lb],
         }
 
         case t when timerafter(time) :> unsigned now :{
-            time = now + MIN_POLL_TIME_US;
+            time = now + 100*MIN_POLL_TIME_US;
             unsigned elapsed = (now-start_of_time)&LED_MAX_COUNT;
             elapsed>>=(20-8);
             unsigned d=0;

--- a/lib_mic_array_board_support/src/board_support.xc
+++ b/lib_mic_array_board_support/src/board_support.xc
@@ -23,7 +23,7 @@ void mabs_button_and_led_server(server interface mabs_led_button_if lb[n_lb],
 #ifndef MIC_BOARD_LED_STCP
         mabs_led_ports_t &leds,
 #else
-        client interface ma_bga167_led_if leds,
+        client interface ma_bga167_led_if? leds,
 #endif
         in port p_buttons){
 
@@ -97,7 +97,9 @@ void mabs_button_and_led_server(server interface mabs_led_button_if lb[n_lb],
 
             for(unsigned i=0; i<13; i++)
                 d=(d>>1)+(0x1000*(led_brightness[i]<=elapsed));
-            leds.set_leds(d);
+
+            if(!isnull(leds))
+                leds.set_leds(d);
 #else
 #if defined(PORT_LED0_TO_7)
             for(unsigned i=0;i<8;i++)


### PR DESCRIPTION
Since we're not using the LEDs on the baseboard, there's no point wasting a core for the server. Making the client nullable fixes this.